### PR TITLE
Change the onnc-tutorial git-clone url from ssh to html link.

### DIFF
--- a/lab_1_Environment_Setup/lab_1.md
+++ b/lab_1_Environment_Setup/lab_1.md
@@ -26,7 +26,7 @@ $ cd ..
 Use the following command to download the tutorial material. There are some example DNN models and code snippets you will use in the subsequent labs.
 
 ```sh
-$ git clone git@github.com:ONNC/onnc-tutorial.git
+$ git clone https://github.com/ONNC/onnc-tutorial.git
 ```
 
 Pull the Docker image from the Docker Hub using the following commands.

--- a/lab_8_Mul_Add_Reordering_and_Fusion/lab_8.md
+++ b/lab_8_Mul_Add_Reordering_and_Fusion/lab_8.md
@@ -70,7 +70,7 @@ $ docker pull onnc/vp
 # Prepare ONNC and tutorial source code.
 $ git clone https://github.com/ONNC/onnc.git
 $ cd onnc; git checkout tags/1.2.0; cd ..
-$ git clone git@github.com:ONNC/onnc-tutorial.git
+$ git clone https://github.com/ONNC/onnc-tutorial.git
 
 # Start the onnc/onnc-community Docker.
 $ docker run -ti --rm -v <absolute/path/to/onnc>:/onnc/onnc -v <absolute/path/to/tutorial>:/tutorial onnc/onnc-community


### PR DESCRIPTION
This is for easy access of this repo by anyone.