### PR TITLE
[lab 6] add current file name in the code example

### DIFF
--- a/lab_6_Manipulating_ONNC_IR/lab_6.md
+++ b/lab_6_Manipulating_ONNC_IR/lab_6.md
@@ -77,6 +77,8 @@ Pass is an abstraction of each execution in ONNC framework. It is designed for m
 First, create a pass by inheriting from the `CustomPass<T>` abstract class.
 
 ```cpp
+// GraphvizONNCIRPass.h
+
 #include <onnc/Core/CustomPass.h>
 
 class GraphvizONNCIRPass : public CustomPass<GraphvizONNCIRPass>


### PR DESCRIPTION
In the code example in [Step 2. Create a new pass](https://github.com/ONNC/onnc-tutorial/blob/master/lab_6_Manipulating_ONNC_IR/lab_6.md#step-2-create-a-new-pass), there is no information about where the snippet is.

Therefore I add the file name `// GraphvizONNCIRPass.h` to indicate the current file as other examples do.
